### PR TITLE
Improve backwards compatibility

### DIFF
--- a/runtime/cudaq/dynamics/spin_operators.cpp
+++ b/runtime/cudaq/dynamics/spin_operators.cpp
@@ -183,16 +183,16 @@ sum_op<spin_handler> spin_handler::minus(int degree) {
 }
 
 namespace spin {
-  sum_op<spin_handler> i(std::size_t target) {
+  product_op<spin_handler> i(std::size_t target) {
     return spin_handler::i(target);
   }
-  sum_op<spin_handler> x(std::size_t target) {
+  product_op<spin_handler> x(std::size_t target) {
     return spin_handler::x(target);
   }
-  sum_op<spin_handler> y(std::size_t target) {
+  product_op<spin_handler> y(std::size_t target) {
     return spin_handler::y(target);
   }
-  sum_op<spin_handler> z(std::size_t target) {
+  product_op<spin_handler> z(std::size_t target) {
     return spin_handler::z(target);
   }
 }

--- a/runtime/cudaq/operators.h
+++ b/runtime/cudaq/operators.h
@@ -69,11 +69,13 @@ protected:
   std::vector<std::vector<HandlerTy>> terms;
   std::vector<scalar_operator> coefficients;
 
-  constexpr sum_op(){};
   sum_op(const sum_op<HandlerTy> &other, bool sized, int size);
   sum_op(sum_op<HandlerTy> &&other, bool sized, int size);
 
 public:
+
+  // Default constructor constructs an identity term.
+  constexpr sum_op() : sum_op(1.0) {}
 
   // called const_iterator because it will *not* modify the sum, 
   // regardless of what is done with the products/iterator
@@ -931,10 +933,10 @@ extern template class sum_op<fermion_handler>;
 
 // Here only for backward compatibility
 namespace spin {
-  sum_op<spin_handler> i(std::size_t target);
-  sum_op<spin_handler> x(std::size_t target);
-  sum_op<spin_handler> y(std::size_t target);
-  sum_op<spin_handler> z(std::size_t target);
+  product_op<spin_handler> i(std::size_t target);
+  product_op<spin_handler> x(std::size_t target);
+  product_op<spin_handler> y(std::size_t target);
+  product_op<spin_handler> z(std::size_t target);
 }
 
 } // namespace cudaq

--- a/runtime/cudaq/spin_op.h
+++ b/runtime/cudaq/spin_op.h
@@ -1,0 +1,11 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/operators.h"


### PR DESCRIPTION
I think this small set of changes makes a tremendous difference in the backwards compatibility of the PR.

From a build perspective, this cuts the number of lines of codes that CUDA-QX would need to change probably by >90%.

I am not convinced in the correctness of the default constructor, though, so please let me know if something looks glaringly wrong (especially regarding the default constructor).